### PR TITLE
Trying to get property of non-object line 143

### DIFF
--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -140,7 +140,7 @@ class Firewall
 
 		if ($ip_found)
 		{
-			return $ip_found->whitelisted ? 'whitelist' : 'blacklist';
+			return $ip_found['whitelisted'] ? 'whitelist' : 'blacklist';
 		}
 
 		return false;


### PR DESCRIPTION
$ip_found is an array and should be used as is $ip_found['whitelisted']