### PR TITLE
Correction to publish config command examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,13 +206,13 @@ To publish the configuration file you'll have to:
 **Laravel 4**
 
 ```
-artisan config:publish pragmarx/firewall
+php artisan config:publish pragmarx/firewall
 ```
 
 **Laravel 5**
 
 ```
-artisan vendor:publish
+php artisan vendor:publish
 ```
 
 ### TODO


### PR DESCRIPTION
publish config commands were missing `php` before `artisan` commands