### PR TITLE
Allow return using abort

### DIFF
--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -256,6 +256,14 @@ class Firewall
 
     public function blockAccess($content = null, $status = null)
     {
+		if ($this->config->get('block_response_abort'))
+		{
+			return abort(
+				$this->config->get('block_response_code'),
+				$content ?: $this->config->get('block_response_message')
+			);
+		}
+
         return Response::make(
 	        $content ?: $this->config->get('block_response_message'),
 	        $status ?: $this->config->get('block_response_code')

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -62,6 +62,8 @@ return array(
 
     'block_response_message' => null,
 
+    'block_response_abort' => false, // return abort() instead of Response::make() - disabled by default
+
     /**
     * Do you wish to redirect non whitelisted accesses to an error page?
     *


### PR DESCRIPTION
This allows the use of Laravel's HTTP Exceptions by returning abort().