### PR TITLE
Replaced route filters with middleware for compatibility with Laravel 5.2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Those IP addresses can
 
 ### Routes
 
-This package provides two route filters:
+This package provides two middleware groups to use in your routes:
 
 `'fw-block-bl'`: to block all blacklisted IP addresses to access filtered routes
 
@@ -29,7 +29,7 @@ This package provides two route filters:
 So, for instance, you could have a blocking group and put all your routes inside it:
 
 ```
-Route::group(['before' => 'fw-block-bl'], function()
+Route::group(['middleware' => 'fw-block-bl'], function () 
 {
     Route::get('/', 'HomeController@index');
 });
@@ -38,14 +38,14 @@ Route::group(['before' => 'fw-block-bl'], function()
 Or you could use both. In the following example the allow group will give free access to the 'coming soon' page and block or just redirect non-whitelisted IP addresses to another, while still blocking access to the blacklisted ones.
 
 ```
-Route::group(['before' => 'fw-block-bl'], function()
+Route::group(['middleware' => 'fw-block-bl'], function () 
 {
     Route::get('coming/soon', function()
     {
         return "We are about to launch, please come back in a few days.";
     });
 
-    Route::group(['before' => 'fw-allow-wl'], function()
+    Route::group(['middleware' => 'fw-allow-wl'], function () 
     {
         Route::get('/', 'HomeController@index');
     });
@@ -194,6 +194,23 @@ Add the Facade to your app/config/app.php:
 ```
 'Firewall' => PragmaRX\Firewall\Vendor\Laravel\Facade::class,
 ```
+
+Add the Middleware groups `fw-block-bl` and `fw-allow-wl` to your app/Http/Kernel.php
+
+```
+protected $middlewareGroups = [
+        ...
+        
+        'fw-block-bl' => [
+            \PragmaRX\Firewall\Middleware\FirewallBlacklist::class,
+        ],
+        'fw-allow-wl' => [
+            \PragmaRX\Firewall\Middleware\FirewallWhitelist::class,
+        ],        
+];
+```
+**Note:** You can add other middleware you have already created to the new groups by simply 
+adding it to the `fw-allow-wl` or `fw-block-bl` middleware group.
 
 Create the migration:
 

--- a/src/Middleware/FirewallBlacklist.php
+++ b/src/Middleware/FirewallBlacklist.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PragmaRX\Firewall\Middleware;
+
+use Closure;
+use PragmaRX\Firewall\Filters\Blacklist;
+
+class FirewallBlacklist
+{
+    protected $blacklist;
+
+    public function __construct(Blacklist $blacklist)
+    {
+        $this->blacklist = $blacklist;
+    }
+    /**
+     * Filter Request through blacklist.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $filterResponse = $this->blacklist->filter();
+        if ($filterResponse != null) {
+            return $filterResponse;
+        }
+        return $next($request);
+    }
+}

--- a/src/Middleware/FirewallWhitelist.php
+++ b/src/Middleware/FirewallWhitelist.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PragmaRX\Firewall\Middleware;
+
+use Closure;
+use PragmaRX\Firewall\Filters\Whitelist;
+
+class FirewallWhitelist
+{
+    protected $whitelist;
+
+    public function __construct(Whitelist $whitelist)
+    {
+        $this->whitelist = $whitelist;
+    }
+    /**
+     * Filter Request through whitelist.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $filterResponse = $this->whitelist->filter();
+        if ($filterResponse != null) {
+            return $filterResponse;
+        }
+        return $next($request);
+    }
+}

--- a/src/Vendor/Laravel/ServiceProvider.php
+++ b/src/Vendor/Laravel/ServiceProvider.php
@@ -64,7 +64,7 @@ class ServiceProvider extends PragmaRXServiceProvider {
             $this->registerClearCommand();
         }
 
-        $this->registerFilters();
+        $this->registerMiddleware();
     }
 
     /**
@@ -152,19 +152,22 @@ class ServiceProvider extends PragmaRXServiceProvider {
                                 );
         });
     }
- 
     /**
-     * Register blocking and unblocking filters
-     * 
+     * Register blocking and unblocking Middleware
+     *
      * @return void
      */
-    private function registerFilters()
+    private function registerMiddleware()
     {
-        $this->app['router']->filter('fw-block-bl', '\PragmaRX\Firewall\Filters\Blacklist');
-
-        $this->app['router']->filter('fw-allow-wl', '\PragmaRX\Firewall\Filters\Whitelist');
+        $this->app['firewall.middleware.blacklist'] = $this->app->share(function($app)
+        {
+            return new FirewallBlacklist;
+        });
+        $this->app['firewall.middleware.whitelist'] = $this->app->share(function($app)
+        {
+            return new FirewallWhitelist;
+        });
     }
-
     /**
      * Return a proper response for blocked access
      *


### PR DESCRIPTION
With the release of Laravel 5.2, route filtering has been deprecated in favor of using middleware ([Laravel 5.1 -> 5.2 Upgrade Guide](https://laravel.com/docs/5.2/upgrade)).   This replaces the route filters in the current master branch with the proper scaffolding to implement middleware in its place.  I added two new middleware files and instructions under Routes and Installation in readme.md to use the new middleware.