### PR TITLE
Fix output on firewall:clear command

### DIFF
--- a/src/Repositories/Firewall/Firewall.php
+++ b/src/Repositories/Firewall/Firewall.php
@@ -187,10 +187,17 @@ class Firewall implements FirewallInterface {
 		/**
 		 * Deletes one by one to also remove them from cache
 		 */
-		foreach ($this->all() as $ip)
-		{
-			$this->delete($ip['ip_address']);
-		}
+        $deleted = 0;
+
+        foreach ($this->all() as $ip)
+        {
+            if ($this->delete($ip['ip_address']))
+            {
+                $deleted++;
+            }
+        }
+
+        return $deleted;
 	}
 
 	private function findIp($ip)


### PR DESCRIPTION
**php artisan firewall:clear --force** now reports _"List cleared"_ when IP addresses were cleared. Previously it was always reporting _"There were no IP addresses to be deleted"_ even when there were.
