### PR TITLE
Broken whitelist fix

### DIFF
--- a/src/Repositories/Firewall/Firewall.php
+++ b/src/Repositories/Firewall/Firewall.php
@@ -310,7 +310,7 @@ class Firewall implements FirewallInterface {
 		{
 			if (
 				(isset($value['ip_address']) && $value['ip_address'] == $ip) ||
-				($key == $ip) ||
+				(strval($key) == $ip) ||
 				($value == $ip)
 			)
 			{


### PR DESCRIPTION
Fix mentioned on #51  and the fix referenced on #54 

Whitelist feature is broken without this. $filterResponse-variable on pragmarx\firewall\src\Middleware\FirewallWhitelist.php will always be null if any ip is in the whitelist inside config/firewall.php.

After changing $key to strval($key), whitelist works again. Tested with various ip's and subnet masks on laravel development env using 'php artisan serve --host 0.0.0.0' to get ipv4 address instead of ipv6.
