### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ This is a result from `firewall:list`:
 +--------------+-----------+-----------+
 ```
 
-###Facade
+### Facade
 
 You can also use the `Firewall Facade` to manage the lists:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
