### PR TITLE
MailMessage from method first argument is address

### DIFF
--- a/src/Notifications/Channels/Mail.php
+++ b/src/Notifications/Channels/Mail.php
@@ -19,7 +19,8 @@ class Mail extends BaseChannel implements Contract
     {
         $message = (new MailMessage())
             ->from(
-                config('firewall.notifications.from.name'),
+                config('firewall.notifications.from.address'),
+                config('firewall.notifications.from.name') .' '.
                 config('firewall.notifications.from.icon_emoji')
             )
             ->subject(config('firewall.notifications.message.request_count.title'))

--- a/src/Notifications/Channels/Mail.php
+++ b/src/Notifications/Channels/Mail.php
@@ -20,7 +20,7 @@ class Mail extends BaseChannel implements Contract
         $message = (new MailMessage())
             ->from(
                 config('firewall.notifications.from.address'),
-                config('firewall.notifications.from.name') .' '.
+                config('firewall.notifications.from.name').' '.
                 config('firewall.notifications.from.icon_emoji')
             )
             ->subject(config('firewall.notifications.message.request_count.title'))


### PR DESCRIPTION
When sending mail notification got the following swift notification: 

```
#329 Swift_RfcComplianceException: Address in mailbox given [Firewall] does not comply with RFC 2822, 3.6.2. in ...
```