### PR TITLE
Add guard for actual list filepaths

### DIFF
--- a/src/Support/IpAddress.php
+++ b/src/Support/IpAddress.php
@@ -65,6 +65,10 @@ class IpAddress
      */
     public function ipV4Valid($item)
     {
+        if (realpath($item) !== false) {
+            return false;
+        }
+
         return SupportIpAddress::ipV4Valid($item);
     }
 


### PR DESCRIPTION
When not guarded, a *filepath string* may be sent to `SupportIpAddress::ipV4Valid()`, finally reaching `inet_pton()`, which will throw a `E_WARNING: inet_pton():: inet_pton(): Unrecognized address <filepath>`

This patch checks for possible valid filepaths while not hitting IO. If the string is a filepath it makes no sense to go on validating for IP format. Result is earlier validation return and avoid of exception report flooding on false alarm.

See https://github.com/antonioribeiro/firewall/issues/113