### PR TITLE
Issue #144 BlockAttack cause Exception in "notify only" mode

### DIFF
--- a/src/Middleware/BlockAttacks.php
+++ b/src/Middleware/BlockAttacks.php
@@ -17,7 +17,7 @@ class BlockAttacks extends Middleware
     public function handle($request, Closure $next)
     {
         if ($this->enabled() && app('firewall')->isBeingAttacked()) {
-            return app('firewall')->responseToAttack();
+            return app('firewall')->responseToAttack() ?: $next($request);
         }
 
         return $next($request);


### PR DESCRIPTION
In case of the Responder returns null we assume that we can going forward to the next Middleware