### PR TITLE
Fix exception when trying to remove from database an ip inside a country

### DIFF
--- a/src/Repositories/IpList.php
+++ b/src/Repositories/IpList.php
@@ -95,13 +95,13 @@ class IpList
      */
     private function removeFromDatabaseList($ip)
     {
-        $ip = $this->find($ip);
+        if($ip = $this->find($ip)) {
+            $ip->delete();
 
-        $ip->delete();
-
-        $this->cache()->forget($ip->ip_address);
-
-        $this->messages()->addMessage(sprintf('%s removed from %s', $ip, $ip->whitelisted ? 'whitelist' : 'blacklist'));
+            $this->cache()->forget($ip->ip_address);
+    
+            $this->messages()->addMessage(sprintf('%s removed from %s', $ip, $ip->whitelisted ? 'whitelist' : 'blacklist'));
+        }
     }
 
     /**


### PR DESCRIPTION
I had an issue when i enlable blacklist whitelisted option.

My ip was inside a whitelisted country and thus the find in database wouldn't work.

Just add a condition to delete only if it finds it first .