### PR TITLE
Fix redirect functionality for redirect_non_whitelisted_config value

### DIFF
--- a/src/Filters/Whitelist.php
+++ b/src/Filters/Whitelist.php
@@ -14,15 +14,21 @@ class Whitelist
         $firewall = app()->make('firewall');
 
         if (!$firewall->isWhitelisted()) {
-            $response = (new Responder())->respond(
-                $this->config()->get('responses.whitelist')
-            );
+            $responses_whitelist = $this->config()->get('responses.whitelist');
 
-            if (!is_null($this->config()->get('responses.whitelist.redirect_to'))) {
+            if (!is_null($this->config()->get('redirect_non_whitelisted_to'))) {
+                $responses_whitelist['redirect_to'] = $this->config()->get('redirect_non_whitelisted_to');
+            }
+
+            if (!is_null($responses_whitelist['redirect_to'])) {
                 $action = 'redirected';
             } else {
                 $action = 'blocked';
             }
+
+            $response = (new Responder())->respond(
+                $responses_whitelist
+            );
 
             $message = sprintf('[%s] IP not whitelisted: %s', $action, $firewall->getIp());
 


### PR DESCRIPTION
I have been using this firewall package for a while.  Thank you!!!  Today for the first time, I had a use case where I needed to assign a url to redirect_non_whitelisted_to in my firewall config.  After doing so, I noticed the redirect was not working for non-whitelisted users.  It returned the http response code defined in the responses.whitelist config value but was completely ignoring the redirect_non_whitelisted_to config value.

I investigated further and noticed a refactor at commit 075b69b, which appears to have removed the condition to check the value of redirect_non_whitelisted_to.  I refactored the Whitelist filter function a little bit to fix this.