### PR TITLE
Fix default config exception on Laravel 9

### DIFF
--- a/src/Support/Responder.php
+++ b/src/Support/Responder.php
@@ -23,7 +23,7 @@ class Responder
         if ($response['abort']) {
             abort(
                 $response['code'],
-                $response['message']
+                $response['message'] ?? ''
             );
         }
 


### PR DESCRIPTION
Fixes https://github.com/antonioribeiro/firewall/issues/185

On Laravel 9 with symfony/http-kernel ^6.0, HttpException constructor parameters became not nullable. With default config; with null whitelist message it throws exception.

Related commit
https://github.com/symfony/http-kernel/commit/22ebd0adf8f09e8c7d442059d1429064e8eb2728#diff-62879e415f9d00628b802f8098f56c2325f473f0a0e97f2f8d2995b6ff8700e2